### PR TITLE
[Feat]: useruid를 tabbarview로 전달하는 로직 구현

### DIFF
--- a/BookBridge/BookBridge.xcodeproj/project.pbxproj
+++ b/BookBridge/BookBridge.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		1DCFB01E2B687D7000250D55 /* FindIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCFB01D2B687D7000250D55 /* FindIdView.swift */; };
 		1DCFB0222B68CB4400250D55 /* FindIdVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCFB0212B68CB4400250D55 /* FindIdVM.swift */; };
 		1DCFB0242B68CD3100250D55 /* FindPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCFB0232B68CD3100250D55 /* FindPasswordView.swift */; };
+		1DFDD1BA2B71B48400B320F7 /* SignInState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFDD1B92B71B48400B320F7 /* SignInState.swift */; };
+		1DFDD1BC2B71BF3D00B320F7 /* tapInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFDD1BB2B71BF3D00B320F7 /* tapInfo.swift */; };
 		1E9CA8884DE9A470795B434C /* Pods_BookBridge_BookBridgeUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38996D702CA8C661E33E70C8 /* Pods_BookBridge_BookBridgeUITests.framework */; };
 		34927C483CF1E10C21B09E15 /* Pods_BookBridgeTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A49B59480B4D646B466C597B /* Pods_BookBridgeTests.framework */; };
 		5A0242152B6D36FF00137AA6 /* LoadingCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0242142B6D36FF00137AA6 /* LoadingCircle.swift */; };
@@ -152,6 +154,8 @@
 		1DCFB01D2B687D7000250D55 /* FindIdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIdView.swift; sourceTree = "<group>"; };
 		1DCFB0212B68CB4400250D55 /* FindIdVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindIdVM.swift; sourceTree = "<group>"; };
 		1DCFB0232B68CD3100250D55 /* FindPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindPasswordView.swift; sourceTree = "<group>"; };
+		1DFDD1B92B71B48400B320F7 /* SignInState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInState.swift; sourceTree = "<group>"; };
+		1DFDD1BB2B71BF3D00B320F7 /* tapInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tapInfo.swift; sourceTree = "<group>"; };
 		2C64B1A5C532C5F1A934328D /* Pods-BookBridge-BookBridgeUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BookBridge-BookBridgeUITests.release.xcconfig"; path = "Target Support Files/Pods-BookBridge-BookBridgeUITests/Pods-BookBridge-BookBridgeUITests.release.xcconfig"; sourceTree = "<group>"; };
 		38996D702CA8C661E33E70C8 /* Pods_BookBridge_BookBridgeUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BookBridge_BookBridgeUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		38E83709A8699EFCEF75F30C /* Pods-BookBridge-BookBridgeUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BookBridge-BookBridgeUITests.debug.xcconfig"; path = "Target Support Files/Pods-BookBridge-BookBridgeUITests/Pods-BookBridge-BookBridgeUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -368,6 +372,7 @@
 				5A3A44142B6C778200B66C81 /* SignUpInputType.swift */,
 				5A3A44162B6C779200B66C81 /* PwdError.swift */,
 				5A3A44182B6C77A300B66C81 /* PwdConfirmError.swift */,
+				1DFDD1B92B71B48400B320F7 /* SignInState.swift */,
 			);
 			path = SignUp;
 			sourceTree = "<group>";
@@ -549,6 +554,7 @@
 				5A5041CD2B6A637A00211CF2 /* PathType.swift */,
 				5ADE79D92B6B2C99005BB3ED /* CertiResult.swift */,
 				5A3A44252B6CB36900B66C81 /* Location.swift */,
+				1DFDD1BB2B71BF3D00B320F7 /* tapInfo.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1031,6 +1037,7 @@
 				5CE454972B68B8CA00874BCE /* AppleLoginView.swift in Sources */,
 				5A5041CE2B6A637A00211CF2 /* PathType.swift in Sources */,
 				7361270F2B6B83BF00943CD7 /* DeleteImageButtonView.swift in Sources */,
+				1DFDD1BC2B71BF3D00B320F7 /* tapInfo.swift in Sources */,
 				73C962A32B68880500D34D3F /* SearchBarView.swift in Sources */,
 				5A3A44222B6C89AE00B66C81 /* LocationViewModel.swift in Sources */,
 				73C962A52B688D4200D34D3F /* BookModel.swift in Sources */,
@@ -1063,6 +1070,7 @@
 				910F491C2B6CC66900C0563E /* CameraModalView.swift in Sources */,
 				5A5041CC2B6A635C00211CF2 /* PathViewModel.swift in Sources */,
 				7361270B2B6B82F100943CD7 /* ImageEditorModalView.swift in Sources */,
+				1DFDD1BA2B71B48400B320F7 /* SignInState.swift in Sources */,
 				1DB39DC02B6B8A5300C1B489 /* BookDetailView.swift in Sources */,
 				1D71C6C32B6C763900EEC95D /* AddBookBtnView.swift in Sources */,
 				5A7A4E262B61DFFD00F79C23 /* BookBridgeApp.swift in Sources */,

--- a/BookBridge/BookBridge/Model/Enum/PathType.swift
+++ b/BookBridge/BookBridge/Model/Enum/PathType.swift
@@ -13,6 +13,6 @@ enum PathType: Hashable {
     case findpassword
     case changepassword
     case certi
-    case home
+    case home(userId: String?)
     case signUp
 }

--- a/BookBridge/BookBridge/Model/Enum/SignUp/SignInState.swift
+++ b/BookBridge/BookBridge/Model/Enum/SignUp/SignInState.swift
@@ -1,0 +1,13 @@
+//
+//  SignInState.swift
+//  BookBridge
+//
+//  Created by 김건호 on 2/6/24.
+//
+
+import Foundation
+
+enum SignInState{
+    case signedIn
+    case signedOut
+}

--- a/BookBridge/BookBridge/Model/Enum/tapInfo.swift
+++ b/BookBridge/BookBridge/Model/Enum/tapInfo.swift
@@ -1,0 +1,14 @@
+//
+//  tapInfo.swift
+//  BookBridge
+//
+//  Created by 김건호 on 2/6/24.
+//
+
+import Foundation
+
+enum tapInfo: String, CaseIterable {
+    case wish = "희망도서"
+    case hold = "보유도서"
+    
+}

--- a/BookBridge/BookBridge/TabBarView.swift
+++ b/BookBridge/BookBridge/TabBarView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct TabBarView: View {
+    let userId : String
+    
     var body: some View {
         TabView {
             // 홈
@@ -32,7 +34,7 @@ struct TabBarView: View {
                 }
             
             // 책장
-            BookShelfView()
+            BookShelfView(userId : userId)
                 .tabItem {
                     Image(systemName: "book.fill")
                     Text("Bookshelf")
@@ -48,6 +50,6 @@ struct TabBarView: View {
     }
 }
 
-#Preview {
-    TabBarView()
-}
+//#Preview {
+//    TabBarView()
+//}

--- a/BookBridge/BookBridge/ViewModel/Login/KakaoLoginViewModel.swift
+++ b/BookBridge/BookBridge/ViewModel/Login/KakaoLoginViewModel.swift
@@ -14,11 +14,8 @@ import FirebaseFirestore
 
 class KakaoLoginViewModel : ObservableObject {
     @Published var state: SignInState = .signedOut
-    
-    enum SignInState{
-        case signedIn
-        case signedOut
-    }
+    @Published var userId : String? = nil
+
     
     func emailAuthSignUp(email: String, userName: String, password: String, completion: (() -> Void)?) {
         
@@ -45,7 +42,7 @@ class KakaoLoginViewModel : ObservableObject {
             }
             if result != nil {
                 self.state = .signedIn
-                print("사용자 이메일: \(String(describing: result?.user.email))")
+                self.userId = result?.user.uid
                 completion(true)
             } else {
                 completion(false)
@@ -164,10 +161,11 @@ class KakaoLoginViewModel : ObservableObject {
                 if success {
                     // 로그인 성공
                     FirestoreSignUpManager.shared.getUserData(email: email) { userData in
-                        if let userData = userData {
+                        if let userData = userData, let uid = userData["id"] as? String {
                             // 사용자 정보 처리
-                            print(userData)
                             self.state = .signedIn
+                            self.userId = uid
+                            
                         } else {
                             // 사용자 데이터를 찾을 수 없음. 필요한 경우 오류 처리
                             print("ERROR")
@@ -177,10 +175,11 @@ class KakaoLoginViewModel : ObservableObject {
                     // 로그인 실패, 새 사용자 등록
                     FirestoreSignUpManager.shared.register(email: email, password: password, nickname: userName) {
                         FirestoreSignUpManager.shared.getUserData(email: email) { userData in
-                            if let userData = userData {
-                                // 사용자 정보 처리                                
-                                print(userData)
-                                self.state = .signedIn
+                            if let userData = userData, let uid = userData["id"] as? String {
+                                // 사용자 정보 처리
+                                self.state = .signedIn                                
+                                self.userId = uid
+                                
                             } else {
                                 // 사용자 데이터를 찾을 수 없음. 필요한 경우 오류 처리
                                 print("ERROR")

--- a/BookBridge/BookBridge/Views/BookShelf/BookShelfView.swift
+++ b/BookBridge/BookBridge/Views/BookShelf/BookShelfView.swift
@@ -10,11 +10,7 @@ import SwiftUI
 
 
 
-enum tapInfo: String, CaseIterable {
-    case wish = "희망도서"
-    case hold = "보유도서"
-    
-}
+
 
 struct BookShelfView: View {
     @StateObject private var viewModel = BookShelfViewModel()
@@ -23,6 +19,8 @@ struct BookShelfView: View {
     @State private var searchText = ""
     @State private var selectedBook: Item?
     @State private var hopeBooks: [Item] = []
+    
+    var userId : String?
     
     var searchBarPlaceholder: String {
         switch selectedPicker {
@@ -36,6 +34,7 @@ struct BookShelfView: View {
     
     
     var body: some View {
+    
         ZStack{
             VStack {
                 Picker("선택", selection: $selectedPicker) {
@@ -47,6 +46,12 @@ struct BookShelfView: View {
                 .onChange(of: selectedPicker) { newValue in
                     viewModel.fetchBooks(for: newValue)
                 }
+                
+                Text("UserId: \(userId ?? "Unknown")")
+                     .foregroundColor(.gray)
+                     .font(.caption)
+                     .padding(.top, 5)
+                
                 Spacer()
                     .frame(height: 20)
                 

--- a/BookBridge/BookBridge/Views/Login/IdLogin/IdLoginView.swift
+++ b/BookBridge/BookBridge/Views/Login/IdLogin/IdLoginView.swift
@@ -98,7 +98,7 @@ struct IdLoginView: View {
             Button(action: {
                 viewModel.login()
                 if viewModel.state == .signedIn {
-                    pathModel.paths.append(.home)
+                    pathModel.paths.append(.home(userId: nil))
                 }
             }, label: {
                 Text("로그인")
@@ -110,7 +110,7 @@ struct IdLoginView: View {
             .cornerRadius(10)
             .onChange(of: viewModel.state) { newState in
                 if newState == .signedIn {
-                    pathModel.paths.append(.home)
+                    pathModel.paths.append(.home(userId:nil))
                 }
             }
         }

--- a/BookBridge/BookBridge/Views/Login/KaKaoLogin/KakaoLoginView.swift
+++ b/BookBridge/BookBridge/Views/Login/KaKaoLogin/KakaoLoginView.swift
@@ -32,9 +32,9 @@ struct KakaoLoginView: View {
             } else {
                 KakaoLoginStatusView(viewModel: viewModel)
             }
-        } .onChange(of: viewModel.state) { newState in
-            if newState == .signedIn {
-                pathModel.paths.append(.home)
+        }.onChange(of: viewModel.state) { newState in
+            if newState == .signedIn, let userId = viewModel.userId {
+                pathModel.paths.append(.home(userId: userId))
             }
         }
         

--- a/BookBridge/BookBridge/Views/Login/LoginView.swift
+++ b/BookBridge/BookBridge/Views/Login/LoginView.swift
@@ -69,7 +69,7 @@ struct LoginView: View {
                         .font(.system(size: 16, weight: .light))
                     
                     Button(action: {
-                        pathModel.paths.append(.home)
+                        pathModel.paths.append(.home(userId: nil))
                     }, label: {
                         Text("둘러보기")
                             .foregroundColor(Color(hex: "3A87FD"))
@@ -114,8 +114,8 @@ struct LoginView: View {
             .padding(20)
             .navigationDestination(for: PathType.self) { pathType in
                 switch pathType {
-                case .home:
-                    TabBarView()
+                case .home(let userId):
+                    TabBarView(userId: userId ?? "")
                         .navigationBarBackButtonHidden()
                 case .certi:
                     EmailCertiView(signUpVM: signUpVM)


### PR DESCRIPTION
- 로그인 성공시 user.uid를 전달받는 로직을 구현했습니다.
- SignInState,tapInfo를 enum 폴더로 분리 시켰습니다.
- 로그인 성공시 .home path에 userId를 전달해 줍니다.