### PR TITLE
[Feat] 채팅 탭바, 앱로고 메시지 개수 표시 기능 추가,

### DIFF
--- a/BookBridge/BookBridge/BookBridgeApp.swift
+++ b/BookBridge/BookBridge/BookBridgeApp.swift
@@ -53,7 +53,6 @@ struct BookBridgeApp: App {
                     .onAppear() {
                         locationViewModel.checkIfLocationServiceIsEnabled()
                         NaverMapApiManager.getNaverApiInfo()
-                        
                     }
                 //                .alert(isPresented: $locationViewModel.showLocationAlert) {
                 //                    Alert(
@@ -84,7 +83,6 @@ struct BookBridgeApp: App {
                     application.registerForRemoteNotifications()
                 }
             }
-            
             return true
         }
         

--- a/BookBridge/BookBridge/TabBarView.swift
+++ b/BookBridge/BookBridge/TabBarView.swift
@@ -44,6 +44,7 @@ struct TabBarView: View {
                             .tabItem {
                                 Image(systemName: "message")
                             }
+                            .badge(userManager.totalNewCount)
                             .tag(1)
                         
                         HomeView()
@@ -100,6 +101,9 @@ struct TabBarView: View {
         }
         .background(.red)
         .tint(Color(hex:"59AAE0"))
+        .onAppear {
+            userManager.updateTotalNewCount()
+        }
         .onChange(of: selectedTab) { newTab in
             if !userManager.isLogin && (newTab == 1 || newTab == 2 || newTab == 3 || newTab == 4) {
                 // 비로그인 상태이며, 로그인이 필요한 탭에 접근 시

--- a/BookBridge/BookBridge/Views/Chat/RoomListView.swift
+++ b/BookBridge/BookBridge/Views/Chat/RoomListView.swift
@@ -40,11 +40,17 @@ struct RoomListView: View {
                                 .cornerRadius(30)
                             
                             VStack(alignment: .leading) {
-                                HStack(alignment: .top) {
-                                    Text(chatRoom.noticeBoardTitle)
-                                        .font(.system(size: 18, weight: .bold))
+                                HStack(alignment: .bottom) {
+                                    Text(viewModel.chatRoomDic[chatRoom.id]?.nickname ?? "")
+                                        .font(.system(size: 18))
                                         .foregroundStyle(Color(.label))
                                         .multilineTextAlignment(.leading)
+                                    
+                                    Text(chatRoom.noticeBoardTitle)
+                                        .font(.system(size: 15))
+                                        .foregroundStyle(Color(.lightGray))
+                                        
+                                        .truncationMode(.tail)
                                     
                                     if !chatRoom.isAlarm {
                                         Image(systemName: "bell.slash.fill")
@@ -55,11 +61,11 @@ struct RoomListView: View {
                                     Spacer()
                                     
                                     Text(chatRoom.timeAgo)
-                                        .font(.system(size: 15, weight: .semibold))
+                                        .font(.system(size: 15))
                                         .foregroundStyle(Color(.lightGray))
                                 }
                                 .padding(.top, 4)
-                                .padding(.bottom, -2)
+                                .padding(.bottom, -8)
                                 
                                 HStack(alignment: .bottom) {
                                     Text(chatRoom.recentMessage)

--- a/BookBridge/BookBridge/Views/MyPage/NoticeBoardItemView.swift
+++ b/BookBridge/BookBridge/Views/MyPage/NoticeBoardItemView.swift
@@ -90,7 +90,7 @@ struct NoticeBoardItemView: View {
         .frame(height: 120, alignment: .center)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .circular)
-                .foregroundColor(Color(red: 230/255, green: 230/255, blue: 230/255))
+                .foregroundColor(Color(.systemGray6))
         )
         .onAppear {
             if !imageLinks.isEmpty {


### PR DESCRIPTION
- 제목 : [Feat] 채팅 탭바, 앱로고 메시지 개수 표시 기능 추가

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔎 작업 내용

- 내게시물 왼쪽 정렬 및 게시물 rectangle 색상 변경
- 채팅 탭바 & 앱 로고 메시지 개수 표시 기능 추가
- 채팅 게시물 제목 -> 닉네임으로 변경

  <br/>

## 이미지 첨부
<img src="https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/102159946/88f0cd53-1d5c-4e9d-8295-5c64e0b59270" width="30%" height="30%"/>
<img src="https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/102159946/b5b628f5-48a6-4d8a-9cd9-77faa481a69e" width="30%" height="30%"/>
<img src="https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/102159946/652decb4-abb6-49f6-bbd5-62fb9b467ec6" width="30%" height="30%"/>

<br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)
- ex) [PJ3T6_BookBridge #84]

<br/>
