### PR TITLE
[Feat] 채팅 키보드 & Plus버튼 토글 시 스크롤뷰 올라가는 기능 추가

### DIFF
--- a/BookBridge/BookBridge/Views/Alert/ToastMessageView.swift
+++ b/BookBridge/BookBridge/Views/Alert/ToastMessageView.swift
@@ -16,7 +16,7 @@ struct ToastMessageView: View {
             Text("주소가 복사되었습니다")
                 .padding()
                 .foregroundColor(.white)
-                .background(Color.gray)
+                .background(Color(.lightGray))
                 .cornerRadius(10)
                 .opacity(isShowing ? 1 : 0)
                 .animation(.easeInOut(duration: 0.3), value: isShowing)

--- a/BookBridge/BookBridge/Views/Chat/MessageItemView.swift
+++ b/BookBridge/BookBridge/Views/Chat/MessageItemView.swift
@@ -11,7 +11,7 @@ import CoreLocation
 
 struct MessageItemView: View {
     @StateObject var viewModel: ChatMessageViewModel
-
+    
     @State var chatLocation: [Double] = [100, 200]
     @State var chatLocationTuple: (Double, Double) = (0, 0)
     @State var isCopyTapped = false
@@ -73,6 +73,12 @@ struct MessageItemView: View {
                                         .onTapGesture {
                                             UIPasteboard.general.setValue(messageModel.message, forPasteboardType: "public.plain-text")
                                             isCopyTapped = true
+                                            showToast = true
+                                            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                                                withAnimation {
+                                                    showToast = false
+                                                }
+                                            }
                                         }
                                 }
                                 
@@ -239,6 +245,12 @@ struct MessageItemView: View {
                 viewModel.getChatImage(urlString: messageModel.imageURL)
             }
         }
+        .overlay(
+            ToastMessageView(isShowing: $showToast)
+                .padding(.bottom, 50) // Bottom padding
+                .zIndex(1),
+            alignment: .bottom
+        )
     }
 }
 

--- a/BookBridge/BookBridge/Views/Chat/MessageItemView.swift
+++ b/BookBridge/BookBridge/Views/Chat/MessageItemView.swift
@@ -15,6 +15,7 @@ struct MessageItemView: View {
     @State var chatLocation: [Double] = [100, 200]
     @State var chatLocationTuple: (Double, Double) = (0, 0)
     @State var isCopyTapped = false
+    @Binding var showToast: Bool
     
     var messageModel: ChatMessageModel
     var partnerId: String
@@ -245,12 +246,6 @@ struct MessageItemView: View {
                 viewModel.getChatImage(urlString: messageModel.imageURL)
             }
         }
-        .overlay(
-            ToastMessageView(isShowing: $showToast)
-                .padding(.bottom, 50) // Bottom padding
-                .zIndex(1),
-            alignment: .bottom
-        )
     }
 }
 

--- a/BookBridge/BookBridge/Views/Chat/MessageListView.swift
+++ b/BookBridge/BookBridge/Views/Chat/MessageListView.swift
@@ -20,7 +20,7 @@ struct MessageListView: View {
     var body: some View {
         ScrollView {
             ScrollViewReader { scrollViewProxy in
-                VStack {
+                LazyVStack {
                     ForEach(viewModel.chatMessages) { chatMessage in
                         MessageItemView(viewModel: viewModel, chatLocation: chatMessage.location, chatLocationTuple: (chatMessage.location[0], chatMessage.location[1]), showToast: $showToast, messageModel: ChatMessageModel(date: chatMessage.date, imageURL: chatMessage.imageURL, location: chatMessage.location, message: chatMessage.message, sender: chatMessage.sender), partnerId: partnerId, partnerImage: partnerImage, uid: uid)
                     }
@@ -29,6 +29,7 @@ struct MessageListView: View {
                     }
                     .id(Self.emptyScrollToString)
                 }
+                .rotationEffect(.degrees(180)).scaleEffect(x: -1, y: 1, anchor: .center)
                 
                 // 자동 스크롤
                 .onReceive(viewModel.$count) { _ in
@@ -38,6 +39,7 @@ struct MessageListView: View {
                 }
             }
         }
+        .rotationEffect(.degrees(180)).scaleEffect(x: -1, y: 1, anchor: .center)
         .overlay(
             ToastMessageView(isShowing: $showToast)
                 .zIndex(1),

--- a/BookBridge/BookBridge/Views/Chat/MessageListView.swift
+++ b/BookBridge/BookBridge/Views/Chat/MessageListView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MessageListView: View {
     @StateObject var viewModel: ChatMessageViewModel
+    @State var showToast = false
     
     var partnerId: String
     var partnerImage: UIImage
@@ -21,7 +22,7 @@ struct MessageListView: View {
             ScrollViewReader { scrollViewProxy in
                 VStack {
                     ForEach(viewModel.chatMessages) { chatMessage in
-                        MessageItemView(viewModel: viewModel, chatLocation: chatMessage.location, chatLocationTuple: (chatMessage.location[0], chatMessage.location[1]), messageModel: ChatMessageModel(date: chatMessage.date, imageURL: chatMessage.imageURL, location: chatMessage.location, message: chatMessage.message, sender: chatMessage.sender), partnerId: partnerId, partnerImage: partnerImage, uid: uid)
+                        MessageItemView(viewModel: viewModel, chatLocation: chatMessage.location, chatLocationTuple: (chatMessage.location[0], chatMessage.location[1]), showToast: $showToast, messageModel: ChatMessageModel(date: chatMessage.date, imageURL: chatMessage.imageURL, location: chatMessage.location, message: chatMessage.message, sender: chatMessage.sender), partnerId: partnerId, partnerImage: partnerImage, uid: uid)
                     }
                     HStack {
                         Spacer()
@@ -37,6 +38,11 @@ struct MessageListView: View {
                 }
             }
         }
+        .overlay(
+            ToastMessageView(isShowing: $showToast)
+                .zIndex(1),
+            alignment: .bottom
+        )
     }
 }
 


### PR DESCRIPTION
- 제목 : [Feat] 채팅 키보드 & Plus버튼 토글 시 스크롤뷰 올라가는 기능 추가

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔎 작업 내용

- 채팅 키보드 & Plus버튼 토글 시 스크롤뷰 올라가는 기능 추가

  <br/>

## 이미지 첨부
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-03-07 at 15 21 24](https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/102159946/1ebf4b28-6324-4166-912e-d5733082d142)

<br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)
- ex) [PJ3T6_BookBridge #84]

<br/>
