### PR TITLE
[Feat]: 채팅방 상단 닉네임 누를 경우 해당 프로필View로 이동 및 내 게시물,오청내역 NaviagationStack…

### DIFF
--- a/BookBridge/BookBridge/Model/Enum/TabPathType.swift
+++ b/BookBridge/BookBridge/Model/Enum/TabPathType.swift
@@ -20,4 +20,6 @@ enum TabPathType : Hashable {
     
     case report(ischat : Bool)
     
+    case noticeboard(naviTitel: String , noticeBoardArray : [String],sortType:[String])
+    
 }

--- a/BookBridge/BookBridge/TabBarView.swift
+++ b/BookBridge/BookBridge/TabBarView.swift
@@ -122,6 +122,10 @@ struct TabBarView: View {
                             
                         case let .report(ischat):
                             ReportView(ischat: ischat)
+                            
+                        case let .noticeboard(naviTitel, noticeBoardArray, sortType):
+                            NoticeBoardView(selectedTab: $selectedTab, naviTitle: naviTitel, noticeBoardArray: noticeBoardArray, sortTypes: sortType)
+                            
                         }
                     }
                     

--- a/BookBridge/BookBridge/Views/Chat/NoticeBoardChatView.swift
+++ b/BookBridge/BookBridge/Views/Chat/NoticeBoardChatView.swift
@@ -99,9 +99,7 @@ struct NoticeBoardChatView: View {
         }
         .padding(.top, 8)
         .padding(.horizontal)
-        .onAppear {
-            print(uid, viewModel.noticeBoardInfo.userId)
-        }
+
         
         Divider()
         

--- a/BookBridge/BookBridge/Views/MyPage/MyPostView.swift
+++ b/BookBridge/BookBridge/Views/MyPage/MyPostView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MyPostView: View {
     @Binding var selectedTab : Int
-
+    @EnvironmentObject private var pathModel: TabPathViewModel
     @StateObject var viewModel: MyPageViewModel
     
     var body: some View {
@@ -17,9 +17,13 @@ struct MyPostView: View {
             Text("나의 게시물")
                 .font(.system(size: 20, weight: .semibold))
                 .padding(.bottom, 10)
+
+            //            NavigationLink {
+//                NoticeBoardView(selectedTab: $selectedTab, naviTitle: "내 게시물", noticeBoardArray: [], sortTypes: ["전체", "진행중", "예약중", "교환완료"])
+//            }
             
-            NavigationLink {
-                NoticeBoardView(selectedTab: $selectedTab, naviTitle: "내 게시물", noticeBoardArray: [], sortTypes: ["전체", "진행중", "예약중", "교환완료"])
+             Button{
+                 pathModel.paths.append(.noticeboard(naviTitel: "내 게시물", noticeBoardArray: [], sortType: ["전체", "진행중", "예약중", "교환완료"]))
             } label: {
                 HStack(spacing: 10) {
                     Text("내 게시물")
@@ -45,8 +49,12 @@ struct MyPostView: View {
                 )
             }
             
-            NavigationLink {
-                NoticeBoardView(selectedTab: $selectedTab, naviTitle: "요청 내역", noticeBoardArray: viewModel.userRequests, sortTypes: ["전체", "예약중", "교환완료"])
+//            NavigationLink {
+//                NoticeBoardView(selectedTab: $selectedTab, naviTitle: "요청 내역", noticeBoardArray: viewModel.userRequests, sortTypes: ["전체", "예약중", "교환완료"])
+//            }
+            
+             Button{
+                 pathModel.paths.append(.noticeboard(naviTitel: "요청내역", noticeBoardArray: viewModel.userRequests, sortType: ["전체","예약중","교환완료"]))
             } label: {
                 HStack(spacing: 10) {
                     Text("요청 내역")


### PR DESCRIPTION


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔎 작업 내용

- 마이페이지에서 내 게시물, 요청내역으로 이동할때 NavigationStack으로 변경하였습니다.
- 채팅방 상단 닉네임을 누를 경우 해당 프로필View로 이동하게 변경하였습니다.

  <br/>

## 이미지 첨부
![Simulator Screen Recording - iPhone 15 - 2024-03-12 at 14 35 32](https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/88571960/9e34eeb0-92ac-43bb-a779-51a0c1e63d1b)

![Simulator Screen Recording - iPhone 15 - 2024-03-12 at 14 35 08](https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/88571960/88af72cd-a04e-4cde-9436-b6d6ebd8d0cc)


<br/>


