### PR TITLE
Fix(284) 실기기 채팅방 이동시 하단이 아닌 상단으로 포커싱 되는 현상

### DIFF
--- a/BookBridge/BookBridge/Views/Chat/MessageListView.swift
+++ b/BookBridge/BookBridge/Views/Chat/MessageListView.swift
@@ -36,13 +36,16 @@ struct MessageListView: View {
                             uid: uid
                         )
                     }
-                    HStack {
-                        Spacer()
+                    HStack{
+                        // 숨겨진 뷰를 사용하여 최하단에 표시
+                        Color.clear
+                            .frame(width: 0, height: 0)
+                            .id(Self.emptyScrollToString)
                     }
-                    .id(Self.emptyScrollToString)
+
+
                 }
                 .rotationEffect(.degrees(180)).scaleEffect(x: -1, y: 1, anchor: .center)
-                
                 // 자동 스크롤
                 .onReceive(viewModel.$count) { _ in
                     withAnimation(.easeOut(duration: 0.5)) {
@@ -63,7 +66,6 @@ struct MessageListView: View {
                            }
                        }
                        .onChange(of: geometry.frame(in: .global).maxY) { newValue in
-                           let scrollViewHeight = geometry.size.height
                            isAtBottom = newValue > lowestMaxY
                        }
                    }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🔎 작업 내용

- 실기기 채팅방 이동시 하단이 아닌 상단으로 포커싱 되는 현상을 수정했습니다

  <br/>

## 이미지 첨부

![Simulator Screen Recording - iPhone 13 mini - 2024-03-25 at 13 05 50](https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/112596655/c6c80aba-c179-42bc-bbdc-12ed30cf3fc8)

<br/>

## ➕ 이슈 링크

- [PJ3T6_BookBridge #284]

<br/>
