### PR TITLE
Refactor(305): 도서검색 정확도 향상 

### DIFF
--- a/BookBridge/BookBridge/ViewModel/SearchBooksViewModel.swift
+++ b/BookBridge/BookBridge/ViewModel/SearchBooksViewModel.swift
@@ -15,7 +15,6 @@ class SearchBooksViewModel: ObservableObject {
     @Published var firstToTalCount: Int = 0
     @Published var isFinish: Bool = true
     @Published var startIndex: Int = 0
-    @Published var saveText: String = ""
     @Published var text: String = ""
     
     var bookApiManger = BookAPIManger()
@@ -23,15 +22,20 @@ class SearchBooksViewModel: ObservableObject {
 
 extension SearchBooksViewModel {
     //도서 api 호출
-    func callBookApi() {
+    func callBookApi(isProgress: Bool) {
         bookApiManger.getData(text: text, startIndex: startIndex) { book in
             DispatchQueue.main.async {
                 if self.firstToTalCount == 0 {
                     self.firstToTalCount = book.totalItems
                     self.searchBooks.totalItems = book.totalItems
                 }
+                // 추가 검색 결과는 뒤로
+                if isProgress{
+                    self.searchBooks.items.append(contentsOf: book.items)
+                }else{
+                    self.searchBooks.items.insert(contentsOf: book.items, at: 0)
+                }
                 
-                self.searchBooks.items.append(contentsOf: book.items)
                 self.startIndex += 20
                 
                 if self.firstToTalCount <= self.startIndex || self.startIndex >= 100 {

--- a/BookBridge/BookBridge/Views/SearchBook/SearchBarView.swift
+++ b/BookBridge/BookBridge/Views/SearchBook/SearchBarView.swift
@@ -23,7 +23,6 @@ struct SearchBarView: View {
                 TextField("검색어를 입력해주세요", text: $viewModel.text)
                     .padding(7)
                     .onChange(of: viewModel.text) { _ in
-                        viewModel.saveText = viewModel.text
                         viewModel.searchBooks.totalItems = 0
                         viewModel.searchBooks.items.removeAll()
                         viewModel.firstToTalCount = 0
@@ -32,7 +31,7 @@ struct SearchBarView: View {
                         
                         if viewModel.text != "" {
                             isEditing = true
-                            viewModel.callBookApi()
+                            viewModel.callBookApi(isProgress: false)
                         } else {
                             isEditing = false
                         }

--- a/BookBridge/BookBridge/Views/SearchBook/SearchResultView.swift
+++ b/BookBridge/BookBridge/Views/SearchBook/SearchResultView.swift
@@ -94,7 +94,7 @@ struct SearchResultView: View {
                         if !viewModel.isFinish {
                             ProgressView()
                                 .onAppear {
-                                    viewModel.callBookApi()
+                                    viewModel.callBookApi(isProgress: true)
                                 }
                         }
                     }


### PR DESCRIPTION

## PR 유형
어떤 변경 사항이 있나요?

- [x] 버그 수정
- [x] 코드 리팩토링


## 🔎 작업 내용

- 도서 검색시 정확도를 향상했어요 ! 
    - ex) 실시간 동기화가 이뤄지다보니 '행복'이라는 단어 검색시 '행'과 '행복' 2개의 데이터가 추가되기에 '행복' 데이터는 뒤로 밀려나는  현상이 있었어요

  <br/>

## 이미지 첨부

|수정 전| 수정 후|
|:--:|:--:|
|<img src="https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/112596655/3f2e2b78-bffe-4e90-835e-d8240e1dd837" width="300">|<img src="https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/112596655/b8a9fe0a-3791-4f73-a3ee-52405b0aa605" width="300">|


<br/>

## ➕ 이슈 링크

[PJ3T6_BookBridge #305 ]

<br/>
