### PR TITLE
Chore(307): 앱 스토어 1.1.4 버전 추가 및 승인 to develop

### DIFF
--- a/BookBridge/BookBridge.xcodeproj/project.pbxproj
+++ b/BookBridge/BookBridge.xcodeproj/project.pbxproj
@@ -2002,7 +2002,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2024041201;
+				CURRENT_PROJECT_VERSION = 2024041603;
 				DEVELOPMENT_ASSET_PATHS = "\"BookBridge/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KVX67TSKSQ;
@@ -2026,7 +2026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bookBridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2050,7 +2050,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2024041201;
+				CURRENT_PROJECT_VERSION = 2024041603;
 				DEVELOPMENT_ASSET_PATHS = "\"BookBridge/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KVX67TSKSQ;
@@ -2074,7 +2074,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bookBridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/BookBridge/BookBridge.xcodeproj/project.pbxproj
+++ b/BookBridge/BookBridge.xcodeproj/project.pbxproj
@@ -2002,7 +2002,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2024032901;
+				CURRENT_PROJECT_VERSION = 2024041201;
 				DEVELOPMENT_ASSET_PATHS = "\"BookBridge/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KVX67TSKSQ;
@@ -2026,7 +2026,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bookBridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2050,7 +2050,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 2024032901;
+				CURRENT_PROJECT_VERSION = 2024041201;
 				DEVELOPMENT_ASSET_PATHS = "\"BookBridge/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = KVX67TSKSQ;
@@ -2074,7 +2074,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bookBridge;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/BookBridge/BookBridge/Views/MyPage/SettingView.swift
+++ b/BookBridge/BookBridge/Views/MyPage/SettingView.swift
@@ -82,7 +82,7 @@ struct SettingView: View {
                 Spacer()
                 
                 //TODO: 버전 업데이트 마다 바꾸기
-                Text("v1.1.2")
+                Text("v1.1.4")
                     .font(.system(size: 17))
                     .foregroundStyle(.black)
             }

--- a/BookBridge/BookBridge/Views/MyPage/SettingView.swift
+++ b/BookBridge/BookBridge/Views/MyPage/SettingView.swift
@@ -82,7 +82,7 @@ struct SettingView: View {
                 Spacer()
                 
                 //TODO: 버전 업데이트 마다 바꾸기
-                Text("v1.0.2")
+                Text("v1.1.2")
                     .font(.system(size: 17))
                     .foregroundStyle(.black)
             }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [x] 빌드 부분 혹은 패키지 매니저 수정


## 🔎 작업 내용

### v1.1.4 
1.1.2 버전에서 AppStore 앱 실행시 튕기는 현상 해결

### v1.1.3
1.0.2 롤백 버전

### v1.1.2

앱 스토어 1.1.2 버전 추가 및 승인

[새로운 기능]
1. 채팅방 텍스트 복사하기 기능이 추가되었어요.
2. 읽은 알림, 안 읽은 알림 기능이 추가되었어요.

[성능 개선]
1. 도서 검색 정확도 향상되었어요.
2. 채팅방 앨범, 사진, 위치공유 추가/보내기 등 버튼 클릭을 개선했어요.
3. 채팅방 입장 시 최근 메시지가 보이도록 수정했어요.
4. 교환 만족도 평가 후 마이페이지에 매너 점수 실시간 반영했어요.
5. 알림 벨 오류가 수정되었어요.

  <br/>

## 이미지 첨부

<img src="https://github.com/APP-iOS3rd/PJ3T6_BookBridge/assets/112596655/a7a17c4f-bba4-4113-aa40-b01d41145dd9" width="50%" height="50%"/>


<br/>

## ➕ 이슈 링크

- [PJ3T6_BookBridge #307 ]

<br/>
